### PR TITLE
Adds .editorconfig file with c# rules and some resharper specific rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ For each project:
    6. Ensure the "Enable Code Analysis" and "Suppress results from generated code" options are enabled on your project.
 2. Add the `StyleCop.Analyzers` NuGet package to your project. This will enable style warnings.
 
+### EditorConfig
+
+The .editorconfig file allows a development team to share consistent coding style rules between different editors and IDEs independent of platform.
+
+EditorConfig plugins look for a file named .editorconfig, starting with the same directory as the file currently being edited and recursively up directories until an .editorconfig file is found with the `root = true` directive.
+
+The .editorconfig file included in this project currently defines a few recommended styles for `c#` development.  
+
+**Useful Resources:**
+
+* [Visual Studio Extension](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.EditorConfig)
+* [Create portable, custom editor settings with EditorConfig](https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options)
+* [.NET coding convention settings for EditorConfig](https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference)
+
 ## Keeping Settings Updated ##
 
 You can safely change your own Team-Shared ReSharper settings, as well as the project-specific `.ruleset` files in your solution to override these baseline settings with your own team's preferences. **Do not** change the `SharedSettings` files in your own repository without getting them changed at the source, or your changes will be overwritten when a teammate updates these files someday.

--- a/SharedSettings/.editorconfig
+++ b/SharedSettings/.editorconfig
@@ -1,0 +1,91 @@
+# EditorConfig - Defines coding styles between different IDEs to promote consistency between developers.
+
+root = true
+
+[*]
+charset = utf-8
+
+[*.cs]
+
+# Indentation
+indent_style = tab
+csharp_indent_case_contents = true
+
+
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first							= true
+
+# Use "this."
+dotnet_style_qualification_for_field						= true : suggestion
+dotnet_style_qualification_for_property						= true : suggestion
+dotnet_style_qualification_for_method						= true : suggestion
+dotnet_style_qualification_for_event						= true : suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members	= true : suggestion
+dotnet_style_predefined_type_for_member_access				= true : suggestion
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers				= for_non_interface_members
+csharp_preferred_modifier_order								= public,internal,protected,private,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer								= true : suggestion
+dotnet_style_collection_initializer							= true : suggestion
+dotnet_style_coalesce_expression							= true : suggestion
+dotnet_style_null_propagation								= true : suggestion
+dotnet_style_explicit_tuple_names							= true : suggestion
+
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types							= true : suggestion
+csharp_style_var_when_type_is_apparent						= true : suggestion
+csharp_style_var_elsewhere									= true : suggestion
+
+# Prefer method-like constructs to have a block body
+csharp_style_expression_bodied_methods						= true : suggestion
+csharp_style_expression_bodied_constructors					= false: none
+csharp_style_expression_bodied_operators					= true : suggestion
+
+# Prefer property-like constructs to have an expression-body
+csharp_style_expression_bodied_properties					= true : suggestion
+csharp_style_expression_bodied_indexers						= true : suggestion
+csharp_style_expression_bodied_accessors					= true : suggestion
+
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check		= true : suggestion
+csharp_style_pattern_matching_over_as_with_null_check		= true : suggestion
+csharp_style_inlined_variable_declaration					= true : suggestion
+csharp_style_throw_expression								= true : suggestion
+csharp_style_conditional_delegate_call						= true : suggestion
+
+# THIS SHOULD BE RECOGNIZED
+csharp_indent_block_contents                                = true
+
+# Newline settings
+csharp_new_line_before_open_brace							= all
+csharp_new_line_before_else									= true
+csharp_new_line_before_catch								= true
+csharp_new_line_before_finally								= true
+csharp_new_line_before_members_in_object_initializers		= true
+csharp_new_line_before_members_in_anonymous_types			= true
+
+# Use braces whenever possible
+csharp_prefer_braces										= true
+
+# ReSharper custom
+csharp_blank_lines_between_using_groups                     = 1
+
+csharp_brace_style =                                        = next_line
+csharp_anonymous_method_declaration_braces                  = next_line_shifted_2
+csharp_accessor_owner_declaration_braces                    = next_line
+csharp_accessor_declaration_braces                          = next_line
+csharp_brace_style                                          = next_line           
+
+csharp_align_linq_query                                     = true
+
+csharp_blank_lines_around_property                          = 1
+csharp_blank_lines_around_single_line_auto_property         = 1
+csharp_blank_lines_around_single_line_property              = 1
+
+blank_lines_around_region                                   = 1
+


### PR DESCRIPTION
Just a first pass introducing some c# rules and playing around with ReSharper specific customizations.  @j2jensen in most cases the EditorConfig rules override other rules (which is the intent) - but it it does seem that in certain situations, StyleCop may be overriding (need to look at this a bit further).

I have not added any JS rules at this point.