### PR TITLE
Stop indenting xmldoc comments.

### DIFF
--- a/SharedSettings/HealthCatalyst.Fabric.ReSharper.DotSettings
+++ b/SharedSettings/HealthCatalyst.Fabric.ReSharper.DotSettings
@@ -81,6 +81,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/JavaScriptCodeFormatting/PLACE_METHOD_DECORATOR_ON_THE_SAME_LINE/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/JavaScriptCodeFormatting/PLACE_PROPERTY_DECORATOR_ON_THE_SAME_LINE/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/JavaScriptCodeFormatting/STICK_COMMENT/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/IndentTagContent/@EntryValue">ZeroIndent</s:String>
 	
 	<s:String x:Key="/Default/CodeStyle/CSharpMemberOrderPattern/CustomPattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
 &lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;


### PR DESCRIPTION
Even though the default behavior when creating xmldoc comments goes like this:
```
/// <summary>
/// description
/// </summary>
```
The Ctrl-E-C Full Reformat option with Resharper adds indents:
```
/// <summary>
///     description
/// </summary>
```
This commit aligns the code formatting with the way the comments are normally added.