### PR TITLE
We are using spaces instead of tabs

### DIFF
--- a/SharedSettings/.editorconfig
+++ b/SharedSettings/.editorconfig
@@ -8,7 +8,8 @@ charset = utf-8
 [*.cs]
 
 # Indentation
-indent_style = tab
+indent_style = space
+indent_size = 4
 csharp_indent_case_contents = true
 
 


### PR DESCRIPTION
I think the platform team is using spaces and so are we. I completely overlooked this before. Please review and merge if acceptable, @j2jensen.