### PR TITLE
Align expression-bodied member rules with visual studio default.

### DIFF
--- a/SharedSettings/.editorconfig
+++ b/SharedSettings/.editorconfig
@@ -43,14 +43,14 @@ csharp_style_var_when_type_is_apparent						= true : suggestion
 csharp_style_var_elsewhere									= true : suggestion
 
 # Prefer method-like constructs to have a block body
-csharp_style_expression_bodied_methods						= true : suggestion
+csharp_style_expression_bodied_methods						= false : none
 csharp_style_expression_bodied_constructors					= false: none
-csharp_style_expression_bodied_operators					= true : suggestion
+csharp_style_expression_bodied_operators					= false : none
 
 # Prefer property-like constructs to have an expression-body
-csharp_style_expression_bodied_properties					= true : suggestion
-csharp_style_expression_bodied_indexers						= true : suggestion
-csharp_style_expression_bodied_accessors					= true : suggestion
+csharp_style_expression_bodied_properties					= true : none
+csharp_style_expression_bodied_indexers						= true : none
+csharp_style_expression_bodied_accessors					= true : none
 
 # Suggest more modern language features when available
 csharp_style_pattern_matching_over_is_with_cast_check		= true : suggestion


### PR DESCRIPTION
@j2jensen, I have aligned the expression-bodied member rules with the Visual Studio default rules.