### PR TITLE
change tabwidth for prettier to 4 spaces

### DIFF
--- a/SharedSettings/.prettierrc
+++ b/SharedSettings/.prettierrc
@@ -2,7 +2,7 @@
   "printWidth": 120,
   "singleQuote": true,
   "useTabs": false,
-  "tabWidth": 2,
+  "tabWidth": 4,
   "semi": true,
   "bracketSpacing": true,
   "trailingComma": "none",


### PR DESCRIPTION
- 4 spaces seems to be the prevailing preference across the org for client side code. 
- Plus, the .editorconfig file was already calling for 4 spaces in javascript files.