### PR TITLE
Update .prettierrc line width to 140

### DIFF
--- a/SharedSettings/.prettierrc
+++ b/SharedSettings/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "printWidth": 120,
+  "printWidth": 140,
   "singleQuote": true,
   "useTabs": false,
   "tabWidth": 4,


### PR DESCRIPTION
Most screens have plenty of real estate for 140 character, and causing inopportune wrapping at 120 makes code harder to read.

Open to pushback, but this is my preference.